### PR TITLE
preserve otelcol-custom.conf during package upgrades

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -54,6 +54,12 @@ Description: Custom OpenTelemetry Collector
  A custom build of the OpenTelemetry Collector with specific components.
 EOF
 
+# Create conffiles to preserve configuration files during upgrades
+echo "Creating conffiles"
+cat > ${PKG_DIR}/DEBIAN/conffiles << 'EOF'
+/etc/otelcol-custom/otelcol-custom.conf
+EOF
+
 # Create postinst script to enable and start service
 echo "Creating postinst script"
 cat > ${PKG_DIR}/DEBIAN/postinst << 'EOF'


### PR DESCRIPTION
## Summary
- Add conffiles entry to Debian package to preserve existing otelcol-custom.conf during upgrades
- Prevents configuration overwrites while allowing config.yaml to be updated with new package versions

## Test plan
- [ ] Build Debian package with updated script
- [ ] Install package on system with existing configuration
- [ ] Upgrade package and verify otelcol-custom.conf is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)