### PR TITLE
Prometheus Exporter for Edge Metrics

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -18,6 +18,7 @@ processors:
 receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.127.0
 
 connectors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.127.0

--- a/config.yaml
+++ b/config.yaml
@@ -16,10 +16,15 @@ service:
       processors: [transform/edge_remap, batch/logs]
       exporters: [otlphttp/dash0/logs]
 
-    metrics:
+    metrics/system:
       receivers: [hostmetrics]
       processors: [filter/cpu_mode, filter/process_cpu_mode, metricstransform/aggregate_cpu, attributes/add_site_name, batch/metrics]
       exporters: [otlphttp/dash0/metrics]
+    
+    metrics/batt-edge:
+      receivers: [prometheus]
+      exporters: [debug, otlphttp/dash0/metrics]
+
 
 receivers:
   journald:
@@ -76,6 +81,15 @@ receivers:
             enabled: true
           system.cpu.time:
             enabled: false
+
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'edge-metrics'
+          scrape_interval: 5s
+          static_configs:
+            - targets: ['127.0.0.1:9000']
+          metrics_path: '/metrics'
 
 connectors:
   routing:


### PR DESCRIPTION
Add Prometheus receiver to the otelcol-custom build, and integrated that into our config for scraping.