### PR TITLE
Config fixes: remove aggregate_cpu (closes #18) and update oltp-http alias

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,22 +9,22 @@ service:
     logs/other:
       receivers: [routing]
       processors: [filter/only_ssh_in_tailscaled, transform/journald, batch/logs]
-      exporters: [otlphttp/dash0/logs]
+      exporters: [otlp_http/dash0/logs]
 
     logs/batt-edge:
       receivers: [routing]
       processors: [transform/edge_remap, batch/logs]
-      exporters: [otlphttp/dash0/logs]
+      exporters: [otlp_http/dash0/logs]
 
     metrics/system:
       receivers: [hostmetrics]
       processors: [filter/cpu_mode, filter/process_cpu_mode, metricstransform/aggregate_cpu, attributes/add_site_name, batch/metrics]
-      exporters: [otlphttp/dash0/metrics, prometheus]
+      exporters: [otlp_http/dash0/metrics, prometheus]
 
     metrics/batt-edge:
       receivers: [prometheus]
       processors: [batch/metrics]
-      exporters: [otlphttp/dash0/metrics]
+      exporters: [otlp_http/dash0/metrics]
 
 receivers:
   journald:
@@ -181,14 +181,14 @@ processors:
         value: ${env:SITE_NAME}
 
 exporters:
-  otlphttp/dash0/logs:
+  otlp_http/dash0/logs:
     endpoint: https://ingress.us-west-2.aws.dash0.com/
     headers:
       Authorization: ${env:DASH0_API_KEY}
     compression: gzip
     encoding: json
 
-  otlphttp/dash0/metrics:
+  otlp_http/dash0/metrics:
     endpoint: https://ingress.us-west-2.aws.dash0.com/
     headers:
       Authorization: ${env:DASH0_API_KEY}

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ service:
 
     metrics/system:
       receivers: [hostmetrics]
-      processors: [filter/cpu_mode, filter/process_cpu_mode, metricstransform/aggregate_cpu, attributes/add_site_name, batch/metrics]
+      processors: [filter/cpu_mode, filter/process_cpu_mode, attributes/add_site_name, batch/metrics]
       exporters: [otlp_http/dash0/metrics, prometheus]
 
     metrics/batt-edge:
@@ -163,16 +163,6 @@ processors:
           attributes["state"] == "user" or 
           attributes["state"] == "system"
         )
-
-  metricstransform/aggregate_cpu:
-    transforms:
-      - include: system.cpu.utilization
-        action: update
-        operations:
-          - action: aggregate_labels
-            label_set: ["state"]
-            aggregation_type: mean
-
 
   attributes/add_site_name:
     actions:


### PR DESCRIPTION
- Update depreciated alias for otlphttp to otlp_http.
- Eliminate problematic aggregate_cpu transform step, which essentially does not work like we expected it to (only averages data points under specific conditions), and modifying the dashboard panels (avg by cpu_mode) solves #18

After closing this I'm going to bump the version to 1.3.1