### PR TITLE
Bump GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: otelcol-custom-${{ matrix.suffix }}
           path: |
@@ -90,10 +90,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -108,7 +108,7 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: Release ${{ steps.version.outputs.version }}
           body: |


### PR DESCRIPTION
- actions/checkout v4/v5 → v6
- actions/upload-artifact v4 → v7
- actions/download-artifact v4 → v8
- softprops/action-gh-release v1 → v3

Removes Node 20 deprecation warnings flagged in CI on the previous PR. Artifact name (`otelcol-custom-${{ matrix.suffix }}`) is unique per matrix leg, so the immutability change in upload-artifact v5+ doesn't bite us.