### PR TITLE
Parameterize journald units and lift device-syslog fields

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,7 @@ service:
 receivers:
   journald:
     directory: /var/log/journal
-    units: ["tailscaled", "batt-edge"]
+    units: ${env:JOURNALD_UNITS}
 
   hostmetrics:
     collection_interval: ${env:METRICS_SCRAPE_INTERVAL}
@@ -115,7 +115,16 @@ processors:
         - set(log.attributes["unit"], log.body["_SYSTEMD_UNIT"])
         - set(log.attributes["message"], log.body["MESSAGE"])
 
-        - keep_keys(log.attributes, ["unit", "message", "site_name"])
+        - set(log.attributes["source_hostname"],   log.body["SOURCE_HOSTNAME"])
+        - set(log.attributes["source_ip"],         log.body["SOURCE_IP"])
+        - set(log.attributes["source_tag"],        log.body["SOURCE_TAG"])
+        - set(log.attributes["source_class"],      log.body["SOURCE_CLASS"])
+        - set(log.attributes["ingest_node"],       log.body["INGEST_NODE"])
+        - set(log.attributes["syslog_identifier"], log.body["SYSLOG_IDENTIFIER"])
+
+        - keep_keys(log.attributes, ["unit", "message", "site_name",
+                                     "source_hostname", "source_ip", "source_tag",
+                                     "source_class", "ingest_node", "syslog_identifier"])
         - keep_keys(log.body, [])
 
   transform/edge_remap:

--- a/otelcol-custom.conf
+++ b/otelcol-custom.conf
@@ -16,3 +16,7 @@ METRICS_SCRAPE_INTERVAL="30s"
 METRICS_BATCH_INTERVAL="15m"
 PROMETHEUS_EXPORTER_ENDPOINT="0.0.0.0:8889"
 PROMETHEUS_TARGETS='["127.0.0.1:9000"]'
+
+# Journald receiver units. Override per-site as needed (e.g. add
+# "network-syslog" on sites with switch/firewall log shipping).
+JOURNALD_UNITS='["tailscaled", "batt-edge"]'


### PR DESCRIPTION
Closes #20.

- Adds `JOURNALD_UNITS` env var with default in `otelcol-custom.conf`. Sites with a `network-syslog.service` rsyslog→journald bridge can override locally without forking `config.yaml`.
- Extends `transform/journald` to lift `SOURCE_IP`, `SOURCE_HOSTNAME`, `SOURCE_TAG`, `SOURCE_CLASS`, `INGEST_NODE`, `SYSLOG_IDENTIFIER` from journal body to log attributes. `error_mode: ignore` keeps it safe for non-syslog units; `keep_keys` allowlist expanded to match.

Rollout note: deploy the `otelcol-custom.conf` default to each site before this YAML lands, otherwise otelcol fails to start with `JOURNALD_UNITS` unset.